### PR TITLE
Add DelayOption

### DIFF
--- a/Sources/RuleKit/Option.swift
+++ b/Sources/RuleKit/Option.swift
@@ -27,7 +27,7 @@
 
 import Foundation
 
-public protocol RuleKitOption {
+public protocol RuleKitOption: Sendable {
     /// If this returns true, the rule will never be fulfilled, and the notification prevented
     /// Defaults to false
     func preventRuleFulfillment(for trigger: any Trigger) async -> Bool
@@ -41,7 +41,7 @@ extension RuleKitOption {
 // MARK: - TriggerFrequency
 
 public struct TriggerFrequencyOption: RuleKitOption {
-    public enum Frequency {
+    public enum Frequency: Sendable {
         case hourly
         case daily
         case weekly

--- a/Sources/RuleKit/Option.swift
+++ b/Sources/RuleKit/Option.swift
@@ -106,3 +106,60 @@ extension RuleKitOption where Self == DispatchQueueOption {
         DispatchQueueOption(queue: queue)
     }
 }
+
+// MARK: - Delay
+
+public struct DelayOption: RuleKitOption {
+    let sleeper: any Sleeper
+    
+    public func preventRuleFulfillment(for trigger: any Trigger) async -> Bool {
+        do {
+            try await sleeper.sleep()
+            return false
+        } catch {
+            return true
+        }
+    }
+}
+
+protocol Sleeper: Sendable {
+    func sleep() async throws
+}
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+private struct DurationSleeper<C>: Sleeper where C: Clock {
+    let duration: C.Instant.Duration
+    let tolerance: C.Instant.Duration?
+    let clock: C
+    
+    func sleep() async throws {
+        try await Task.sleep(for: duration, tolerance: tolerance, clock: clock)
+    }
+}
+
+private struct NanosecondsSleeper: Sleeper {
+    let duration: UInt64
+    
+    func sleep() async throws {
+        try await Task.sleep(nanoseconds: duration)
+    }
+}
+
+extension RuleKitOption where Self == DelayOption {
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+    public static func delay<C>(
+        for duration: C.Instant.Duration,
+        tolerance: C.Instant.Duration? = nil,
+        clock: C = ContinuousClock()
+    ) -> RuleKitOption where C: Clock {
+        let sleeper = DurationSleeper(duration: duration, tolerance: tolerance, clock: clock)
+        return DelayOption(sleeper: sleeper)
+    }
+    
+    public static func delay(
+        nanoseconds duration: UInt64
+    ) -> RuleKitOption {
+        let sleeper = NanosecondsSleeper(duration: duration)
+        return DelayOption(sleeper: sleeper)
+    }
+}

--- a/Sources/RuleKit/Rule.swift
+++ b/Sources/RuleKit/Rule.swift
@@ -27,7 +27,7 @@
 
 import Foundation
 
-public protocol Rule {
+public protocol Rule: Sendable {
     var isFulfilled: Bool { get async }
 }
 
@@ -78,7 +78,7 @@ extension Rule {
 // MARK: Condition rule
 
 public struct ConditionRule: Rule {
-    let condition: () async -> Bool
+    let condition: @Sendable () async -> Bool
 
     public var isFulfilled: Bool {
         get async {
@@ -86,13 +86,13 @@ public struct ConditionRule: Rule {
         }
     }
 
-    public init(condition: @escaping () async -> Bool) {
+    public init(condition: @escaping @Sendable () async -> Bool) {
         self.condition = condition
     }
 }
 
 extension Rule where Self == ConditionRule {
-    public static func condition(_ condition: @escaping () async -> Bool) -> Rule {
+    public static func condition(_ condition: @escaping @Sendable () async -> Bool) -> Rule {
         ConditionRule(condition: condition)
     }
 }
@@ -101,7 +101,7 @@ extension Rule where Self == ConditionRule {
 
 public struct EventRule: Rule {
     let event: RuleKit.Event
-    let condition: (RuleKit.DonatedEvent) async -> Bool
+    let condition: @Sendable (RuleKit.DonatedEvent) async -> Bool
 
     public var isFulfilled: Bool {
         get async {
@@ -113,14 +113,14 @@ public struct EventRule: Rule {
         }
     }
 
-    public init(event: RuleKit.Event, condition: @escaping (RuleKit.DonatedEvent) async -> Bool) {
+    public init(event: RuleKit.Event, condition: @escaping @Sendable (RuleKit.DonatedEvent) async -> Bool) {
         self.event = event
         self.condition = condition
     }
 }
 
 extension Rule where Self == EventRule {
-    public static func event(_ event: RuleKit.Event, condition: @escaping (RuleKit.DonatedEvent) async -> Bool) -> Rule {
+    public static func event(_ event: RuleKit.Event, condition: @escaping @Sendable (RuleKit.DonatedEvent) async -> Bool) -> Rule {
         EventRule(event: event, condition: condition)
     }
 }

--- a/Tests/RuleKitTests/RuleKitTests.swift
+++ b/Tests/RuleKitTests/RuleKitTests.swift
@@ -86,6 +86,37 @@ final class RuleKitTests: XCTestCase {
         XCTAssertTrue(measuredDuration >= duration)
     }
 
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+    func testParallelizedTrigger() async throws {
+        let duration = Duration.seconds(5)
+        await RuleKit.Event.testEvent.reset()
+        
+        let delayExpectation = XCTestExpectation()
+        RuleKit.setRule(Self.testCallback, triggering: {
+            print("Rule with DelayOption triggered")
+            delayExpectation.fulfill()
+        }, options: [.delay(for: duration)], .anyOf([
+            .event(.testEvent) {
+                $0.donations.count > 0
+            }
+        ]))
+        
+        let expectation = XCTestExpectation()
+        RuleKit.setRule(Self.testCallback, triggering: {
+            print("Rule without DelayOption triggered")
+            expectation.fulfill()
+        }, options: [], .anyOf([
+            .event(.testEvent) {
+                $0.donations.count > 0
+            }
+        ]))
+        
+        await RuleKit.Event.testEvent.donate()
+        // If the rules are checked in parallel, then the rule without delay option should
+        // get triggered before the rule with the delay option.
+        await fulfillment(of: [expectation, delayExpectation], enforceOrder: true)
+    }
+
     func testNotificationRuleTriggeringResultBuilder() async throws {
         await RuleKit.Event.testEvent.reset()
         RuleKit.setRule(triggering: Self.testNotification, .allOf {


### PR DESCRIPTION
Adds an option to artificially delay checking/fulfilling a rule.

In order to prevent other rules from being affected by the delay option `triggerFulfilledRules` now uses `TaskGroup` to check determine if the rules should trigger.

This required to make `Rule` conform to `Sendable`
